### PR TITLE
Fix description to use the local 'entries' array instead of fetching the...

### DIFF
--- a/ObserverSet/ObserverSet.swift
+++ b/ObserverSet/ObserverSet.swift
@@ -80,7 +80,7 @@ public class ObserverSet<Parameters>: Printable {
             entries = self.entries
         }
         
-        let strings = self.entries.map{
+        let strings = entries.map{
             entry in
             (entry.object === self
                 ? "\(entry.f)"


### PR DESCRIPTION
... property again, which is not safe and defeats the purpose of the synchronized block
